### PR TITLE
Fix add and delete lesson bug

### DIFF
--- a/client/src/components/LessonCard.js
+++ b/client/src/components/LessonCard.js
@@ -143,7 +143,7 @@ class LessonCard extends Component {
                   rows={4}
                   id="notes"
                   addonBefore="Notes:"
-                  autosize
+                  autosize="true"
                   defaultValue={notes}
                   onChange={this.onChangeNotes}
                 />

--- a/client/src/components/LessonPool.js
+++ b/client/src/components/LessonPool.js
@@ -66,7 +66,8 @@ class LessonPool extends Component {
         }),
       })
         .then(res => res.json())
-        .then(() => {
+        .then(newLessonInfo => {
+          item['id'] = newLessonInfo.id;
           this.setState(prevState => ({
             allLessons: [...prevState.allLessons, item],
             showModal: false,
@@ -111,7 +112,7 @@ class LessonPool extends Component {
                     id="titleAdd"
                     allowClear
                     addonBefore="Title:"
-                    autosize
+                    autosize="true"
                     defaultValue=""
                   />
                 </Col>

--- a/client/src/components/RosterCard.js
+++ b/client/src/components/RosterCard.js
@@ -103,7 +103,7 @@ export default class RosterCard extends Component {
                   rows={4}
                   id="notes"
                   addonBefore="Notes:"
-                  autosize
+                  autosize="true"
                   defaultValue={notes}
                   onChange={this.onChangeNotes}
                 />

--- a/controllers/lessons_controller.js
+++ b/controllers/lessons_controller.js
@@ -16,8 +16,10 @@ const index = async (req, res, next) => {
 /* Add a lesson to the lesson pool. */
 const create = async (req, res, next) => {
   try {
-    await knex('lesson').insert(req.body);
-    return res.status(201).send({ title: req.body.title });
+    const data = await knex('lesson')
+      .insert(req.body)
+      .returning('id');
+    return res.status(201).send({ title: req.body.title, id: data[0] });
   } catch (error) {
     return res.status(500).json({ error });
   }


### PR DESCRIPTION
Fixes a bug with adding and deleting new lessons. Previously, when you add a lesson, the server doesn't return back the id of the created lesson, meaning that if you immediately delete the lesson, the client doesn't know which id to tell the server to delete. 

Now, the server returns the created lesson's id to the frontend so that both can stay synced.